### PR TITLE
fixes quote and indentation

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": “bower_components"
+  "directory": "bower_components"
 }


### PR DESCRIPTION
I think we should use two spaces for indentation and change the quote `“` to a typical double quote here.